### PR TITLE
Small chores

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Create release
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
-name: Test
+name: Run tests
 
 on:
   workflow_dispatch:
   pull_request_target:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,16 +2,18 @@ name: Run tests
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
 
       - name: Run tests
         run: go test -fuzz Fuzz -fuzztime 10s

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/knei-knurow/frames
 
-go 1.16
+go 1.18


### PR DESCRIPTION
- improve naming in github actions
- require go 1.18 (because of fuzzing)
